### PR TITLE
feat(drivers): improve drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ build-linux-drivers: build-linux-kernel
 	cp $(MODULE_DRIVER_DIR)/* $(OS_DRIVERS_DIR)
 	# generate linux driver header
 	cd $(CALLING_DIR) && \
-		$(PYTHON_DIR)/bootstrap.py $(MODULE_NAME) -f gen_linux_driver_header -o `realpath $(CURDIR)/software/drivers --relative-to=$(CALLING_DIR)`
+		$(PYTHON_DIR)/bootstrap.py $(MODULE_NAME) -f gen_linux_driver_headers -o `realpath $(CURDIR)/software/drivers --relative-to=$(CALLING_DIR)`
 	# compile linux kernel module
 	make -C $(OS_DRIVERS_DIR) all LINUX_DIR=`realpath $(LINUX_DIR) --relative-to=./software/drivers` MODULE_NAME=$(MODULE_NAME)
 	# copy drivers to rootfs overlay

--- a/software/drivers/Makefile
+++ b/software/drivers/Makefile
@@ -1,5 +1,11 @@
 obj-m += $(MODULE_NAME).o
 
+# Note: each driver should have a driver.mk segment included here
+# include only running from linux kernel makefiles
+ifdef M
+include $(M)/driver.mk
+endif
+
 LINUX_DIR ?= ../../submodules/linux-5.15.98
 
 # Options to cross compile for RISCV system in a x86 host machine
@@ -10,7 +16,7 @@ all:
 	make -C $(LINUX_DIR) $(CROSS_COMPILE_OPS) M=$(CURDIR) modules
 
 clean: linux-clean
-	find . -not -name "Makefile" -type f -delete
+	find . -not -name "Makefile" -not -name "iob_class_utils*" -type f -delete
 
 linux-clean:
 	make -C $(LINUX_DIR) $(CROSS_COMPILE_OPS) M=$(CURDIR) clean

--- a/software/drivers/iob_class/iob_class_utils.c
+++ b/software/drivers/iob_class/iob_class_utils.c
@@ -1,0 +1,75 @@
+/* iob_class_utils.c: common utility functions for iob_class drivers */
+
+#include <linux/io.h>
+#include <linux/uaccess.h>
+
+#include "iob_class_utils.h"
+
+static int char_to_u32(char *, u32, u32 *);
+
+/* TODO: add error checking */
+u32 iob_data_read_reg(void __iomem *regbase, u32 addr, u32 nbits) {
+	u32 value = 0;
+	switch (nbits) {
+	case 8:
+		value = (u32) ioread8(regbase + addr);
+		break;
+	case 16:
+		value = (u32) ioread16(regbase + addr);
+		break;
+	default:
+		value = ioread32(regbase + addr);
+		break;
+	}
+	return value;
+}
+
+/* TODO: add error checking */
+void iob_data_write_reg(void __iomem *regbase, u32 value, u32 addr, u32 nbits) {
+	switch (nbits) {
+	case 8:
+		iowrite8(value, regbase + addr);
+		break;
+	case 16:
+		iowrite16(value, regbase + addr);
+		break;
+	default:
+		iowrite32(value, regbase + addr);
+		break;
+	}
+}
+
+/* read 1-4 nbytes from char array into u32 value
+ * NOTE: assumes bytes[] at least nbytes long
+ * NOTE2: assumes little-endian byte order
+ * return:
+ *      0 on success
+ *      -EINVAL on invalid nbytes
+ * */
+static int char_to_u32(char *bytes, u32 nbytes, u32 *value) {
+    if (nbytes > 4){
+        return -EINVAL;
+    }
+
+	*value = 0; /* reset value */
+	while (nbytes--) {
+		*value = (*value << 8) | ((u32)bytes[nbytes]);
+	}
+	return 0;
+}
+
+/* read `size` bytes from user `buf` into `value`
+ * return:
+ *      0 on success
+ *      -EINVAL on invalid size or char_to_u32 error
+ *      -EFAULT on copy error
+ */
+int read_user_data(const char *buf, int size, u32 *value) {
+	char kbuf[4] = {0}; // max 32 bit value
+    if ((size < 1) || (size > 4)){
+        return -EINVAL;
+    }
+	if (copy_from_user(&kbuf, buf, size))
+		return -EFAULT;
+	return char_to_u32(kbuf, size, value);
+}

--- a/software/drivers/iob_class/iob_class_utils.h
+++ b/software/drivers/iob_class/iob_class_utils.h
@@ -1,0 +1,19 @@
+#ifndef H_IOB_CLASS_UTILS_H
+#define H_IOB_CLASS_UTILS_H
+
+#include <linux/cdev.h>
+
+u32 iob_data_read_reg(void __iomem *, u32, u32);
+void iob_data_write_reg(void __iomem *, u32, u32, u32);
+int read_user_data(const char *, int, u32 *);
+
+struct iob_data {
+	dev_t devnum;
+	struct cdev cdev;
+	void __iomem *regbase;
+	resource_size_t regsize;
+	struct device *device;
+    struct class *class;
+};
+
+#endif // H_IOB_CLASS_UTILS_H


### PR DESCRIPTION
- add iob_class utility functions with common functions to be used by multiple drivers
- drivers' makefile imports `driver.mk` makefile segment with
  `$(MODULE_NAME)-obj := src1.o src2.o`
list of objects for the target module driver to compile
- update with latest main branch
- use `gen_linux_driver_headers` to generate linux headers