### PR TITLE
fix(CI): fix CI flow for latest ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,22 @@ WORKDIR /iob_linux
 
 # Update the package index and install dependencies
 RUN apt-get update && \
-    apt-get install -y device-tree-compiler autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build bash binutils bzip2 cpio g++ gcc git gzip make patch perl rsync sed tar unzip wget file sudo locales mercurial libncurses5-dev libfdt-dev libglib2.0-dev libpixman-1-dev
+    apt-get install -y device-tree-compiler autoconf automake autotools-dev curl python3 python3-setuptools libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build bash binutils bzip2 cpio g++ gcc git gzip make patch perl rsync sed tar unzip wget file sudo locales mercurial libncurses5-dev libfdt-dev libglib2.0-dev libpixman-1-dev
 
 RUN git clone https://github.com/riscv-collab/riscv-gnu-toolchain.git && \
     cd riscv-gnu-toolchain  && git checkout 2023.02.25 && \
     ./configure --prefix=/opt/riscv --enable-multilib && make linux -j`nproc` && \
     rm -rf /iob_linux/riscv-gnu-toolchain
     
-RUN wget https://download.qemu.org/qemu-7.2.0.tar.xz && tar xvJf qemu-7.2.0.tar.xz && rm qemu-7.2.0.tar.xz && \
-    cd qemu-7.2.0 && ./configure --target-list=riscv32-softmmu,riscv32-linux-user && \
-    make -j`nproc` && make install && rm -r /iob_linux/qemu-7.2.0
+RUN wget https://download.qemu.org/qemu-7.2.9.tar.xz && tar xvJf qemu-7.2.9.tar.xz && rm qemu-7.2.9.tar.xz && \
+    cd qemu-7.2.9 && ./configure --target-list=riscv32-softmmu,riscv32-linux-user && \
+    make -j`nproc` && make install && rm -r /iob_linux/qemu-7.2.9
+
+RUN apt-get install -y gcc-12 g++-12 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 20 && \
+    update-alternatives --config gcc && \
+    update-alternatives --config g++
 
 # riscv-gnu-toolchain dependencies: apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build
 # QEMU dependencies: apt-get install git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build


### PR DESCRIPTION
- ubuntu:latest now points to 24.04, this requires multiple fixes to dockerfile: - install python3-setuptools to replace deprecated distutils - install qemu-7.2.9, since qemu-7.2.0 compilation fails with some errors - install gcc-12 and set as default version to compile micro python for buildroot without errors